### PR TITLE
Fix typos in `circuit_test.go`, `constraints_test.go`, and `app.go`

### DIFF
--- a/examples/slot/circuit_test.go
+++ b/examples/slot/circuit_test.go
@@ -17,7 +17,7 @@ func TestCircuit(t *testing.T) {
 	check(err)
 
 	account := common.HexToAddress("0x5427FEFA711Eff984124bFBB1AB6fbf5E3DA1820")
-	// By specifying the optional parameter index = 1, the app will pin the stroage
+	// By specifying the optional parameter index = 1, the app will pin the storage
 	// data at a fixed spot in the DataInput. This allows us to later directly
 	// access this "special" data in circuit.
 	app.AddStorage(sdk.StorageData{
@@ -57,7 +57,7 @@ func TestE2E(t *testing.T) {
 	check(err)
 
 	account := common.HexToAddress("0x5427FEFA711Eff984124bFBB1AB6fbf5E3DA1820")
-	// By specifying the optional parameter index = 1, the app will pin the stroage
+	// By specifying the optional parameter index = 1, the app will pin the storage
 	// data at a fixed spot in the DataInput. This allows us to later directly
 	// access this "special" data in circuit.
 	app.AddStorage(sdk.StorageData{

--- a/sdk/app.go
+++ b/sdk/app.go
@@ -475,7 +475,7 @@ func (q *BrevisApp) PrepareRequest(
 func (q *BrevisApp) buildSendRequestCalldata(args ...interface{}) ([]byte, error) {
 	sendRequest, ok := q.brevisRequest.Methods["sendRequest"]
 	if !ok {
-		return nil, fmt.Errorf("method sendRequest not fonud in abi")
+		return nil, fmt.Errorf("method sendRequest not found in abi")
 	}
 	inputs, err := sendRequest.Inputs.Pack(args...)
 	if err != nil {

--- a/test/constraints_test.go
+++ b/test/constraints_test.go
@@ -30,16 +30,16 @@ func TestBn254VkHash(t *testing.T) {
 		OutputCommitment:     [2]frontend.Variable{100, 100},
 	}
 
-	assigment := &CustomPlonkCircuit{
+	assignment := &CustomPlonkCircuit{
 		InputCommitmentsRoot: 100,
 		TogglesCommitment:    100,
 		OutputCommitment:     [2]frontend.Variable{100, 100},
 	}
 
-	err := test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err := test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 
-	witnessFull, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+	witnessFull, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 
 	witnessPublic, err := witnessFull.Public()


### PR DESCRIPTION
1. **`circuit_test.go`**:
   - Fixed `stroage` → `storage` in multiple comments.

2. **`app.go`**:
   - Corrected `fonud` → `found` in an error message related to ABI method lookup.

3. **`constraints_test.go`**:
   - Fixed `assigment` → `assignment` in variable declarations and method calls.
