### PR TITLE
fix codec mapping in getStoreCodec function

### DIFF
--- a/store/utils.go
+++ b/store/utils.go
@@ -13,9 +13,9 @@ func getStoreCodec(codec string) (encoding.Codec, error) {
 		// Allowed, as gokv will pick its default Codec
 		return nil, nil
 	case "json":
-		return encoding.Gob, nil
-	case "gob":
 		return encoding.JSON, nil
+	case "gob":
+		return encoding.Gob, nil
 	default:
 		return nil, fmt.Errorf("unsupported codec %s", codec)
 	}


### PR DESCRIPTION
Fixes a critical bug in the getStoreCodec function where JSON and Gob codecs were incorrectly swapped. Now the function correctly returns encoding.JSON for "json" requests and encoding.Gob for "gob" requests, ensuring proper data serialization and deserialization.